### PR TITLE
Globus Compute/FuncX deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ uvicorn LLM_service_api:app --reload
 
 This approach will deploy infrence tasks to a Globus Compute endpoint.
 
-# Set-up Endpoint
+### Set-up Endpoint
 
 1. In a conda or virtual environment on Sunspot, install the necessary packages to run Globus Compute:
 ```
@@ -391,9 +391,9 @@ pip install globus-compute-sdk globus-compute-endpoint
 
 2. It is necessary to hack your installation of `globus-compute-endpoint` to tell the endpoint process to communicate through a local port of your choosing, rather than attempting a TCP connection itself.
 
-In your environment, look for the `endpoint.py` file in the endpoint code.  For example, in a local `miniconda` installation that has an environment called `anl_llma-13b` it would be here:
+In your environment, look for the `endpoint.py` file in your installation's `globus_compute_endpoint/endpoint` directory.  For example, in a local `miniconda` installation that has an environment called `anl_llma-13b` it would be here:
 ```
-~/miniconda3/envs/my-demo-env/lib/python3.9/site-packages/globus_compute_endpoint/endpoint/endpoint.py
+~/miniconda3/envs/anl_llma-13b/lib/python3.9/site-packages/globus_compute_endpoint/endpoint/endpoint.py
 ```
 
 In this file, look for the routine `start_endpoint`.  Within this routine look for the creation of an object called `reg_info`.  This object contains the endpoint registration info that needs to be edited.  Directly below `reg_info` paste the following code:
@@ -429,9 +429,9 @@ Note the use of `localhost:50000`; this is the local port on the sunspot login n
 
 3. Configure your endpoint.  
 
-At the path `~/.globus_compute/<ENDPOINT_NAME>` there is a file called `config.yaml`.  We want to replace that file with a, there is a sample endpoint config file.  
+At the path `~/.globus_compute/<ENDPOINT_NAME>` there is a file called `config.yaml`.  We want to replace that file with a config file similar to the sample file [config.yaml](funcx/config.yaml).  
 
-# Set-up tunnel
+### Set-up tunnel
 
 1. On your local machine, install [`stunnel`](https://www.stunnel.org).  If you have `homebrew` on your local machine, you can use it to install:
 ```

--- a/funcx/config.yaml
+++ b/funcx/config.yaml
@@ -1,0 +1,37 @@
+engine:
+    type: HighThroughputEngine
+
+    # Each worker has access to one tile
+    available_accelerators: ["0.0","0.1","1.0","1.1","2.0","2.1","3.0","3.1","4.0","4.1","5.0","5.1"]
+
+    strategy:
+        type: SimpleStrategy
+        max_idletime: 300
+
+    address:
+        type: address_by_interface
+        ifname: bond0
+
+    provider:
+        type: PBSProProvider
+
+        launcher:
+            type: MpiExecLauncher
+            # Ensures 1 manger per node, work on all 64 cores
+            bind_cmd: --cpu-bind
+            overrides: --depth=208 --ppn 1
+
+        account: Aurora_deployment
+        queue: workq
+        cpus_per_node: 208
+        select_options: "system=sunspot,place=scatter"
+
+        # Node setup: activate necessary conda environment and such
+        worker_init: ". /home/csimpson/miniconda3/etc/profile.d/conda.sh; conda activate my-demo-env"
+
+        walltime: 00:60:00 
+        nodes_per_block: 1 # This is the number of nodes in a batch job that the endpoint will submit 
+        init_blocks: 0
+        min_blocks: 0 # This is the minimum number of batch jobs the endpoint will run; as it is set to 0, it will not submit any batch jobs until it has work.
+        max_blocks: 1 # This is the maximum number of batch jobs the endpoint will allow to run at one time; the number of batch jobs it will submit depends on how many tasks it has to run
+	

--- a/funcx_service_13b/config.yaml
+++ b/funcx_service_13b/config.yaml
@@ -1,8 +1,12 @@
 engine:
-    type: HighThroughputEngine
+    type: GlobusComputeEngine
 
     # Each worker has access to one tile
     available_accelerators: ["0.0","0.1","1.0","1.1","2.0","2.1","3.0","3.1","4.0","4.1","5.0","5.1"]
+    cpu_affinity: block  # Assigns cpus in sequential order                                                                 
+    prefetch_capacity: 0  # Increase if you have many more tasks than workers                                                    
+    cores_per_worker: 16 # How many workers per core dictates total workers per node    
+
 
     strategy:
         type: SimpleStrategy
@@ -27,9 +31,9 @@ engine:
         select_options: "system=sunspot,place=scatter"
 
         # Node setup: activate necessary conda environment and such
-        worker_init: ". /home/csimpson/miniconda3/etc/profile.d/conda.sh; conda activate my-demo-env"
+        worker_init: "$HOME/LLM-service-api/funcx_service_13b/worker_init.sh"
 
-        walltime: 00:60:00 
+        walltime: 00:15:00 
         nodes_per_block: 1 # This is the number of nodes in a batch job that the endpoint will submit 
         init_blocks: 0
         min_blocks: 0 # This is the minimum number of batch jobs the endpoint will run; as it is set to 0, it will not submit any batch jobs until it has work.

--- a/funcx_service_13b/config.yaml
+++ b/funcx_service_13b/config.yaml
@@ -1,12 +1,13 @@
 engine:
+
+    # This engine uses the HighThroughputExecutor
     type: GlobusComputeEngine
 
-    # Each worker has access to one tile
-    available_accelerators: ["0.0","0.1","1.0","1.1","2.0","2.1","3.0","3.1","4.0","4.1","5.0","5.1"]
-    cpu_affinity: block  # Assigns cpus in sequential order                                                                 
+    #available_accelerators: ["0,1","2,3","4,5"] # 2 GPUs per worker
+    available_accelerators: ["0.0","0.1","1.0","1.1","2.0","2.1","3.0","3.1","4.0","4.1","5.0","5.1"] # one tile per worker
+    cpu_affinity: block  # Assigns cpus in sequential order                                                                    
     prefetch_capacity: 0  # Increase if you have many more tasks than workers                                                    
-    cores_per_worker: 16 # How many workers per core dictates total workers per node    
-
+    cores_per_worker: 16 # Number of cpu threads per worker
 
     strategy:
         type: SimpleStrategy
@@ -30,12 +31,15 @@ engine:
         cpus_per_node: 208
         select_options: "system=sunspot,place=scatter"
 
-        # Node setup: activate necessary conda environment and such
-        worker_init: "$HOME/LLM-service-api/funcx_service_13b/worker_init.sh"
+        # e.g., "#PBS -l filesystems=home:grand:eagle\n#PBS -k doe"
+        # scheduler_options: "#PBS -l filesystems=home:grand:eagle"
 
-        walltime: 00:15:00 
-        nodes_per_block: 1 # This is the number of nodes in a batch job that the endpoint will submit 
+        # Node setup: activate necessary conda environment and such
+        worker_init: source /home/csimpson/LLM-service-api/funcx_service_13b/worker_init.sh
+
+        walltime: 00:15:00
+        nodes_per_block: 1 # Increase this to increase the number of nodes per job
         init_blocks: 0
-        min_blocks: 0 # This is the minimum number of batch jobs the endpoint will run; as it is set to 0, it will not submit any batch jobs until it has work.
-        max_blocks: 1 # This is the maximum number of batch jobs the endpoint will allow to run at one time; the number of batch jobs it will submit depends on how many tasks it has to run
-	
+        min_blocks: 0
+        max_blocks: 1 # Increase this to increase the number of jobs in the workflow
+

--- a/funcx_service_13b/register_function.py
+++ b/funcx_service_13b/register_function.py
@@ -1,16 +1,12 @@
 import globus_compute_sdk
 gc = globus_compute_sdk.Client()
 
-def call_model_13b (command, output_dir="$HOME/LLM-service-api/funcx_service_13b/output"):
+def call_model_13b (command):
     import subprocess
-    import os
     
-    cmd = f"echo 'Running on tile with affinity ZE_AFFINITY_MASK={os.getenv('ZE_AFFINITY_MASK')}'; python {command[0]} {' '.join(command[1:])}"                                                                                     
-    res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/bin/bash')
+    res = subprocess.run(command.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     return res.returncode, res.stdout.decode("utf-8"), res.stderr.decode("utf-8")
 
 model_13b = gc.register_function(call_model_13b)
 print(f"Function id for model_13b is {model_13b}")
-
-    

--- a/funcx_service_13b/register_function.py
+++ b/funcx_service_13b/register_function.py
@@ -1,0 +1,16 @@
+import globus_compute_sdk
+gc = globus_compute_sdk.Client()
+
+def call_model_13b (command, output_dir="$HOME/LLM-service-api/funcx_service_13b/output"):
+    import subprocess
+    import os
+    
+    cmd = f"echo 'Running on tile with affinity ZE_AFFINITY_MASK={os.getenv('ZE_AFFINITY_MASK')}'; python {command[0]} {' '.join(command[1:])}"                                                                                     
+    res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/bin/bash')
+
+    return res.returncode, res.stdout.decode("utf-8"), res.stderr.decode("utf-8")
+
+model_13b = gc.register_function(call_model_13b)
+print(f"Function id for model_13b is {model_13b}")
+
+    

--- a/funcx_service_13b/run_batch.py
+++ b/funcx_service_13b/run_batch.py
@@ -1,0 +1,37 @@
+import globus_compute_sdk
+import os
+import sys
+import uuid
+
+BATCH_SIZE=12
+
+# Replace these IDs with your endpoint & function!
+function_id = '8f28d7ed-d49b-4d24-ada2-aca7a2ad6fc2'
+sunspot_endpoint = '7bf0f111-8636-49d1-9af8-c3d76de56286'
+
+gce = globus_compute_sdk.Executor(endpoint_id=sunspot_endpoint)
+
+def run_code(command,output_dir):
+    tasks = []
+    for i in range(BATCH_SIZE):
+        tasks.append(gce.submit_to_registered_function(args=[command], function_id=function_id))        
+    for i,t in enumerate(tasks):
+        ret_code,stdout,stderr = t.result()
+        task_output_dir = os.path.join(output_dir,str(i))
+        os.makedirs(task_output_dir)
+        if ret_code != 0:
+            print(f"Task failed! {t.result()}")
+        with open(os.path.join(task_output_dir,"llama.stdout"),"w") as f:
+            f.write(stdout)
+        with open(os.path.join(task_output_dir,"llama.stderr"),"w") as f:
+            f.write(stderr)
+    print("Call for model 13B completed")
+
+
+if __name__ == "__main__":
+
+    #command = 'python /lus/gila/projects/Aurora_deployment/anl_llama/13B/intel-extension-for-pytorch/examples/gpu/inference/python/llm/text-generation/run_llama.py --device xpu --model-dir /lus/gila/projects/Aurora_deployment/anl_llama/model_weights/llma_models/llma-2-convert13B --dtype float16 --ipex --greedy'
+    command = " ".join(["python"]+sys.argv[1:])
+    print(command)
+    output_dir = os.path.join("./output",str(uuid.uuid4()))
+    run_code(command,output_dir)

--- a/funcx_service_13b/worker_init.sh
+++ b/funcx_service_13b/worker_init.sh
@@ -1,0 +1,6 @@
+source /soft/datascience/conda-2023-01-31/miniconda3/bin/activate
+conda activate /lus/gila/projects/Aurora_deployment/conda_env_llm/anl_llma-13b
+export SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 
+export ENABLE_SDP_FUSION=1
+source /soft/compilers/oneapi/2023.05.15.001/oneapi/compiler/latest/env/vars.sh
+source /soft/compilers/oneapi/2023.05.15.001/oneapi/mkl/latest/env/vars.sh


### PR DESCRIPTION
This adds instructions for deploying the model through Globus Compute, including instructions on how to create a tunnel, scripts to register the function, and scripts to deploy work to endpoint.